### PR TITLE
Add handling for npm 3+ flat dependency structure

### DIFF
--- a/lib/chart.js
+++ b/lib/chart.js
@@ -11,7 +11,19 @@ var vm = require('vm');
 var initialized;
 var window;
 var Chartist;
-var chartistSource =  fs.readFileSync(path.resolve(__dirname, '../node_modules/chartist/dist/chartist.js'));
+var chartistSource;
+try {
+    // NPM 2: nested dependency resolution
+    chartistSource = fs.readFileSync(path.resolve(__dirname, '../node_modules/chartist/dist/chartist.js'));
+} catch (error) {
+    try {
+        // NPM 3+: flat dependency resolution
+        chartistSource = fs.readFileSync(path.resolve(__dirname, '../../chartist/dist/chartist.js'));
+    } catch (error) {
+        // Chartist module not found!
+        throw error;
+    }
+}
 var createWindow = co.wrap(function * () {
   var window = yield new Promise((resolve, reject) =>
     jsdom.env({ html: '', done: (error, window) => error ? reject(error) : resolve(window) })


### PR DESCRIPTION
The chart module will now attempt a quick search for the chartist module source at a nested location (npm v2) and a flattened location (npm v3+). It will also throw an error if it cannot be found at either location, which would imply an installation issue of some kind.