### PR TITLE
feature Allow Chartist options for chart

### DIFF
--- a/lib/chart.js
+++ b/lib/chart.js
@@ -67,4 +67,10 @@ var generate = co.wrap(function * (type, options, data) {
   return container.innerHTML;
 });
 
-module.exports = generate;
+var ChartistCo = co.wrap(function * () {
+  if (!initialized) yield initialize();
+  return Chartist;
+});
+
+module.exports.generate = generate;
+module.exports.Chartist = ChartistCo;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var co = require('co');
-var generateChart = require('./chart');
+var generateChart = require('./chart').generate;
 var generateLegend = require('./legend');
 var R = require('ramda');
 var Ru = require('@panosoft/ramda-utils');


### PR DESCRIPTION
@alexgig
Chartist have some settings that should be set as a property e.g
Chartist cannot be required https://github.com/gionkunz/chartist-js/issues/780
```js
{
  axisX: {
    type: Chartist.FixedScaleAxis,
    divisor: 5,
  }
```
Please help, how it can be properly done?
I'm started with `lib/chart.js` with idea that it can be used like
```js

const Chartist = yield require('node-chartist/lib/chart').Chartist();

```
Is this approach the best?
Should it be expanded to `lib/index.js`?
