### PR TITLE
add wrapHtml option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 !node_modules/canvas.js
 
 bundle.js
+/.vs

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ __Arguments__
 
   - `legend` - A boolean used to determine whether a legend should be generated. Defaults to `true`.
 
+  - `wrapHtml` - A boolean used to determine whether a `<div>` wrapping the SVG should be generated. Defaults to `true`.
+
+  - A pure SVG will be generated if set both `legend` and `wrapHtml` to `false`.
+
 
 - `data` - An object containing data used to generate the chart. The structure of this object depends on chart `type`. Please refer to the [Chartist Api Documentation](http://gionkunz.github.io/chartist-js/api-documentation.html) for complete details.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,11 +25,12 @@ const generate = R.curryN(3, co.wrap(function * (type, options, data) {
     // process options
     options = is.function(options) ? options(Chartist) : options;
     if (is.not.json(options)) throw new TypeError('options must be an object or a function that returns an object.');
-    options = Ru.defaults({ legend: true }, options);
+    options = Ru.defaults({ legend: true, wrapHtml: true }, options);
     // create chart
     const chart = yield generateChart(Chartist, window, type, options, data);
-    const legend = options.legend ? generateLegend(data) : '';
-    return `<div class="ct-chart">${chart}${legend}</div>`;
+    const legend = options.legend ? generateLegend(data) : '';    
+
+    return options.wrapHtml ? `<div class="ct-chart">${chart}${legend}</div>` : `${chart}${legend}`;
 }));
 
 module.exports = generate;


### PR DESCRIPTION
set `wrapHtml = false`, the output of `generate()` will be SVG markup only (without the wrapping div)

Use `wrapHtml = false`, `legend = false` we can have pure SVG output
ignore `.vs` from Visual Studio IDE

update README